### PR TITLE
Improve design of EO Browser highlights on PS sandbox data

### DIFF
--- a/_build/css/main.css
+++ b/_build/css/main.css
@@ -359,11 +359,18 @@ table>tbody+tbody{
   margin-right: 10px;
 }
 
+.container33 .info {
+  height: 100px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  display: flex;
+  flex-direction: column;
+}
+
 .container33 .title {
   font-weight: bold;
-  margin-top: 1px;
 }
 
 .container33 .text {
-  margin-top: 5px;
+  flex-grow: 1;
 }

--- a/_build/css/main.css
+++ b/_build/css/main.css
@@ -347,23 +347,23 @@ table>tbody+tbody{
   padding: 10px;
 }
 
-.image-card {
+.container33 .image-card {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
-.imagette {
+.container33 .imagette {
   width: 100px;
   height: 100px;
   margin-right: 10px;
 }
 
-.title {
+.container33 .title {
   font-weight: bold;
   margin-top: 1px;
 }
 
-.text {
+.container33 .text {
   margin-top: 5px;
 }

--- a/collections/planetscope/sandbox-data.md
+++ b/collections/planetscope/sandbox-data.md
@@ -44,9 +44,9 @@ To access data over your own areas and times of interest, [contact Planet](https
             <div class="title">Planalmira, Brazil</div>
             <div class="text">
                 2022-05-01 to 2023-04-30<br>
-                25km<sup>2</sup><br>
-                Visualise in EO Browser ->
+                25km<sup>2</sup>
             </div>
+            <div class="eob-link">Visualise in EO Browser -></div>
         </div>
     </div>
     <div class="image-card">
@@ -55,9 +55,9 @@ To access data over your own areas and times of interest, [contact Planet](https
             <div class="title">Cairo, Egypt</div>
             <div class="text">
                 2022-05-01 to 2023-04-30<br>
-                25km<sup>2</sup><br>
-                Visualise in EO Browser ->
+                25km<sup>2</sup>
             </div>
+            <div class="eob-link">Visualise in EO Browser -></div>
         </div>
     </div>
     <div class="image-card">
@@ -66,9 +66,9 @@ To access data over your own areas and times of interest, [contact Planet](https
             <div class="title">Perth, Australia</div>
             <div class="text">
                 2022-05-01 to 2023-04-30<br>
-                25km<sup>2</sup><br>
-                Visualise in EO Browser ->
+                25km<sup>2</sup>
             </div>
+            <div class="eob-link">Visualise in EO Browser -></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- made the CSS rules for EO Browser highlights safer by defining the ancestor element, so in case the same class names are used elsewhere, these rules don't break the design there
- moved the EO Browser link to the bottom of the parent element (more aligned with the bottom edge of the highlight image), so it follows the design better